### PR TITLE
Added ngrok bin from valet in paths

### DIFF
--- a/etc/paths
+++ b/etc/paths
@@ -4,4 +4,5 @@
 /usr/sbin
 /sbin
 /Users/caddy/.composer/vendor/bin
+/Users/caddy/.composer/vendor/laravel/valet/bin
 /opt/homebrew/bin


### PR DESCRIPTION
No longer need to have `ngrok` installed independently