### PR TITLE
Fixed nah git alias

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -3,8 +3,9 @@
 alias gs="git status"
 alias gl="git log"
 alias gcs="git commit -s -S"
-alias nah="git checkout -- . && git reset --hard HEAD && git clean -df"
+alias nah="git reset --hard;git clean -df"
 alias wip="git add . && git commit -s -S -m 'Work In Progress' -m 'This is a trash commit to save changes'"
+alias pop="git stash pop && git restore --staged ."
 
 # ZSH
 

--- a/.aliases
+++ b/.aliases
@@ -5,7 +5,6 @@ alias gl="git log"
 alias gcs="git commit -s -S"
 alias nah="git reset --hard;git clean -df"
 alias wip="git add . && git commit -s -S -m 'Work In Progress' -m 'This is a trash commit to save changes'"
-alias pop="git stash pop && git restore --staged ."
 
 # ZSH
 


### PR DESCRIPTION
- Removed pathspec discard as it breaks in sub-directories
- Don't reset to a HEAD commit that may not exist (newly initialized repos)
- alias slightly faster running second command in the same shell process by delimiter `;` instead of spawning a new one by the `&&` operator