### PR TITLE
Ignore vendor at the root only

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -1,3 +1,3 @@
 .DS_Store
-vendor
+/vendor
 *.pub


### PR DESCRIPTION
* Sometimes I need to override third party files published in a nested fashion.